### PR TITLE
[fix] fix parsing bug possibly skipping some key/value pairs

### DIFF
--- a/nvram-parser.js
+++ b/nvram-parser.js
@@ -135,13 +135,13 @@ format ends with two nulls
       body = buf.slice(NvramParser.headerbuf.length, +(-NvramParser.footerbuf.length) + 1 || 9e9);
       bound = 0;
       settings = {};
-      while ((-1 < bound && bound < body.length)) {
+      while (body.length) {
         bound = buffertools.indexOf(body, NvramParser.separator, 0);
         if (bound > -1) {
           pair = body.slice(0, +(bound - 1) + 1 || 9e9);
           body = body.slice(bound + 1);
         } else {
-          pair = body;
+          return NvramParser.error("format not supported, missing null terminator");
         }
         pair = pair.toString("utf8");
         eq = pair.indexOf("=");

--- a/src/nvram-parser.iced
+++ b/src/nvram-parser.iced
@@ -66,7 +66,7 @@ class NvramParser
     settings = {}
 
     # loop through each null character
-    while -1 < bound < body.length
+    while body.length
       bound = buffertools.indexOf body, @separator, 0
 
       # slice pair and remaining body from each side of null char
@@ -74,7 +74,7 @@ class NvramParser
         pair = body[..bound-1]
         body = body[bound+1..]
       else
-        pair = body
+        return @error "format not supported, missing null terminator"
 
       # slice pair at first index of "=" ("=" is valid char in value after "=")
       pair = pair.toString "utf8"


### PR DESCRIPTION
- No longer use the length of the previous key/value pair as a factor in
  determining whether or not to continue parsing the data.

Prior to this change it was possible for the parser to skip some
key/value pairs if they were near the end of the file and preceded by
a long key/value pair.

Closes https://github.com/doublerebel/nvram-cfg-parser/pull/6

---

Thanks for making this parser. It was not working properly for me because it was omitting some pairs, so I made this change.

I cannot give you cfg files that will reproduce this issue but I can describe how it happens. Basically there are some public keys that are stored in long strings of hex and then the next key/value pair can't be read because of that. For example a long key is written (a public key) and bound = 273 and the remaining keys are in body and body.length = 95, so for the next iteration (in javascript):
      while ((-1 < 273 && 273 < 95)) {
So it misses 95 bytes left in the body.

Also I changed it so that it would return `@error` if bound was ever -1 because that shouldn't ever happen. As an aside one thing I notice about returning errors is that they don't affect the exit code, for example if I return `@error` the error is shown and it does return but the exit code is still 0 and stdout is "undefined".